### PR TITLE
Removed "encode" on color in get_job_status

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -216,7 +216,7 @@ class JenkinsJob:
             if "color" not in response:
                 return self.EXCL_STATE
             else:
-                return response['color'].encode('utf-8')
+                return str(response['color'])
 
         except Exception as e:
             self.module.fail_json(msg='Unable to fetch job information, %s' % to_native(e), exception=traceback.format_exc())


### PR DESCRIPTION
### SUMMARY
Remove encoding on return of get_job_status in jenkins_job module. Fixes enabling/disabling Jenkins Job when using Python3 (tested in 3.8.1).

### ISSUE TYPE
- Bugfix Pull Request

### COMPONENT NAME
- jenkins_job

### ADDITIONAL INFORMATION

#### Expectation

Using Python3, be able to enable and disable Jenkins Job using boolean on "enabled" parameter idempotently.

#### Reality

Using Python3:
- Job State: Enabled | Ansible parameter "enabled: true" => No change (PASS: Expected)
- Job State: Disabled | Ansible parameter "enabled: true" => No change (FAIL: Should update)
- Job State: Enabled | Ansible parameter "enabled: false" => Change to disabled (PASS)
- Job State: Disabled | Ansible parameter "enabled: false" => Change to disabled (FAIL: Should show no change)



#### Reproducing:

**STEP 1**: Start Docker Container for Jenkins and get PASSWORD from log
``` SHELL
docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
```

**STEP 2**: Upload Jenkins Job to container (Copy XML below to config.xml file on disk)
``` SHELL
curl -i -X POST --user "admin:<JENKINS_PASSWORD" --data-binary "@config.xml" -H "Content-Type: text/xml" http://localhost:8080/createItem?name=Ping
```

config.xml (save as "config.xml" for us with curl)
``` XML
<project>
<actions/>
<description/>
<keepDependencies>false</keepDependencies>
<properties/>
<scm class="hudson.scm.NullSCM"/>
<canRoam>true</canRoam>
<disabled>false</disabled>
<blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
<blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
<triggers>
<hudson.triggers.TimerTrigger>
<spec>*/2 * * * *</spec>
</hudson.triggers.TimerTrigger>
</triggers>
<concurrentBuild>false</concurrentBuild>
<builders>
<hudson.tasks.Shell>
<command>ping -c 2 localhost</command>
</hudson.tasks.Shell>
</builders>
<publishers/>
<buildWrappers/>
</project>
```

**STEP 3**: Run Playbook
```
ansible-playbook jenkins_job_update.yml
```

jenkins_job_update.yml
``` YAML
---
- name: Run locally
  hosts: localhost
  become: false
  gather_facts: false

  tasks:
  - name: Stop/Start Jenkins Job - Ping
    jenkins_job:
      name: "Ping"
      enabled: false
      user: admin
      password: "e80021f6300d4abfb626ffd4d029e5ff"
      url: http://localhost:8080
```